### PR TITLE
Fix a bug when the pagesize or pageindex is larger than an int16. Hap…

### DIFF
--- a/src/SQLiteErrorLog.cs
+++ b/src/SQLiteErrorLog.cs
@@ -239,8 +239,8 @@ namespace Elmah.SQLite
             {
                 var parameters = command.Parameters;
 
-                parameters.Add("@PageIndex", DbType.Int16).Value = pageIndex;
-                parameters.Add("@PageSize", DbType.Int16).Value = pageSize;
+                parameters.Add("@PageIndex", DbType.Int32).Value = pageIndex;
+                parameters.Add("@PageSize", DbType.Int32).Value = pageSize;
 
                 connection.Open();
 


### PR DESCRIPTION
…pens when more than 32000 errors have been saved